### PR TITLE
Add api-key-fetch servlet

### DIFF
--- a/servlets/api-key-fetch/Cargo.toml
+++ b/servlets/api-key-fetch/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "api-key-fetch"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+serde_json = "1.0"
+reqwest = { version = "0.11", features = ["json"] }

--- a/servlets/api-key-fetch/Cargo.toml
+++ b/servlets/api-key-fetch/Cargo.toml
@@ -7,5 +7,6 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
+extism-pdk = "1.0.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-reqwest = { version = "0.11", features = ["json"] }

--- a/servlets/api-key-fetch/servlet.json
+++ b/servlets/api-key-fetch/servlet.json
@@ -1,0 +1,29 @@
+{
+  "schema": {
+    "tools": [
+      {
+        "name": "api-key-fetch",
+        "description": "Fetches content from a URL, replacing $APIKEY with a configured API key",
+        "inputSchema": {
+          "type": "object",
+          "required": ["url"],
+          "properties": {
+            "url": {
+              "type": "string",
+              "description": "The URL to fetch from. Use $APIKEY where the API key should be inserted"
+            }
+          }
+        }
+      }
+    ]
+  },
+  "description": "Fetch with API key substitution",
+  "requirements": {
+    "v0": {
+      "configs": ["api-key"],
+      "network": {
+        "required": true
+      }
+    }
+  }
+}

--- a/servlets/api-key-fetch/src/lib.rs
+++ b/servlets/api-key-fetch/src/lib.rs
@@ -1,0 +1,35 @@
+use serde_json::Value;
+use std::error::Error;
+
+#[derive(Debug)]
+pub struct Config {
+    pub api_key: String,
+}
+
+impl TryFrom<&Value> for Config {
+    type Error = Box<dyn Error>;
+
+    fn try_from(value: &Value) -> Result<Self, Self::Error> {
+        let api_key = value["api-key"]
+            .as_str()
+            .ok_or("Missing or invalid api-key")?
+            .to_string();
+        Ok(Config { api_key })
+    }
+}
+
+pub async fn api_key_fetch(input: &Value, config: &Config) -> Result<Value, Box<dyn Error>> {
+    let url = input["url"]
+        .as_str()
+        .ok_or("Missing or invalid url parameter")?;
+    
+    // Replace $APIKEY with the actual API key
+    let url = url.replace("$APIKEY", &config.api_key);
+    
+    // Fetch the content
+    let response = reqwest::get(&url).await?;
+    let text = response.text().await?;
+    
+    // Return the response as a JSON string
+    Ok(Value::String(text))
+}


### PR DESCRIPTION
This PR adds a new servlet that enables fetching content from URLs while substituting an API key.

## Features
- Reads an API key from the servlet configuration (`api-key` config key)
- Accepts a URL parameter that can contain `$APIKEY` as a placeholder
- Replaces `$APIKEY` with the configured value before fetching
- Returns the fetched content as a string

## Example Usage
```json
{
    "url": "https://api.example.com/data?key=$APIKEY"
}
```

## Configuration
The servlet requires an `api-key` configuration value to be set:
```json
{
    "api-key": "your-secret-key-here"
}
```

## Implementation Details
- Uses reqwest for HTTP requests
- Handles errors appropriately
- Returns plain text responses
- Built as a cdylib for WebAssembly compilation